### PR TITLE
Skip failure domain checks if value is false

### DIFF
--- a/nova_scheduler_filters/failure_domain_filter.py
+++ b/nova_scheduler_filters/failure_domain_filter.py
@@ -5,6 +5,7 @@ from nova import context as nova_context
 from nova import objects
 from nova.scheduler import filters
 from oslo_log import log as logging
+from oslo_utils import strutils
 
 LOG = logging.getLogger(__name__)
 
@@ -18,8 +19,13 @@ class FailureDomainFilter(filters.BaseHostFilter):
     RUN_ON_REBUILD = False
 
     def host_passes(self, host_state, spec_obj):
-        # Include the host if the scheduler hint is not set
-        if not spec_obj.get_scheduler_hint("different_failure_domain"):
+        # Include the host if the scheduler hint is set to false (or unset)
+        if (
+            strutils.bool_from_string(
+                spec_obj.get_scheduler_hint("different_failure_domain")
+            )
+            is False
+        ):
             return True
 
         # Include the host if the instance is not in a server group

--- a/nova_scheduler_filters/tests/unit/test_failure_domain_filter.py
+++ b/nova_scheduler_filters/tests/unit/test_failure_domain_filter.py
@@ -25,6 +25,19 @@ class TestFailureDomainFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(context=mock.sentinel.ctx, scheduler_hints=None)
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
+    def test_different_failure_domain_false(self):
+        """
+        Ensures that the filter passes if the scheduler hint is set to false.
+        """
+
+        host = fakes.FakeHostState("host1", "node1", {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            scheduler_hints=dict(different_failure_domain=["false"]),
+            instance_group=objects.InstanceGroup(hosts=[]),
+        )
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
     def test_no_instance_group(self):
         """
         Ensures that the filter passes if the instance is not part of a


### PR DESCRIPTION
When the different failure domain is set to false, the filter
does run anyways and cause issues.
